### PR TITLE
Correct repository url and support newer versions of Spark and Scala

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM jupyter/pyspark-notebook
 
 USER root
 
-RUN $SPARK_HOME/bin/spark-shell --packages graphframes:graphframes:0.8.0-spark2.4-s_2.11
-RUN wget http://dl.bintray.com/spark-packages/maven/graphframes/graphframes/0.8.0-spark2.4-s_2.11/graphframes-0.8.0-spark2.4-s_2.11.jar -qO $SPARK_HOME/jars/graphframes.jar
+RUN $SPARK_HOME/bin/spark-shell --repositories https://repos.spark-packages.org/ --packages graphframes:graphframes:0.8.1-spark3.0-s_2.12
+RUN wget https://repos.spark-packages.org/graphframes/graphframes/0.8.1-spark3.0-s_2.12/graphframes-0.8.1-spark3.0-s_2.12.jar -qO $SPARK_HOME/jars/graphframes-0.8.1-spark3.0-s_2.12.jar
 
 USER $NB_UID
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ I found that connecting [GraphFrames](https://github.com/graphframes/graphframes
 
 ```
 python 3.7
-spark 2.4
-graphframes 0.8.0
+spark 3.1
+graphframes 0.8.1
 ```
 
 Build the image and take note of the `id` to run the container. Be sure to forward port `8888` when starting it:
 
 ```bash
-docker build .
-docker run -t --rm -p 8888:8888 <image-id>
+docker build -t jupyter/pyspark-graphframes-notebook .
+docker run -t --rm -p 8888:8888 jupyter/pyspark-graphframes-notebook
 ```
 
 The terminal output will contain the notebook url (`localhost:8888`) and a token. Visit the url in a browser and use the token to authenticate.


### PR DESCRIPTION
1. Dockerfile: Changed repository url to get Graphframes library as dl.bintray is no longer available
2. Dockerfile: Used Graphframes library version that supports Spark 3 and Scala 2.12. 
2. README - updated decriptions